### PR TITLE
fix: make pipeline step settings optional and fix TrOCR device mismatch

### DIFF
--- a/src/htrflow/models/huggingface/trocr.py
+++ b/src/htrflow/models/huggingface/trocr.py
@@ -66,6 +66,21 @@ class TrOCR(BaseModel, ConfidenceMixin):
         self.decoding = model_kwargs.pop("decoding", None)
         self.model = VisionEncoderDecoderModel.from_pretrained(model, **model_kwargs)
         self.model.to(self.device)
+
+        # Workaround for transformers' TrOCRSinusoidalPositionalEmbedding: its
+        # get_embedding() always creates weights on CPU, and the checkpoint stores
+        # them as a meta tensor (no actual data). Both issues cause a device mismatch
+        # at inference time: position_ids are on CUDA but self.weights is on CPU/meta.
+        # Fix: recompute the sinusoidal weights from scratch and place them on the
+        # correct device. get_embedding() is pure math so no checkpoint data is needed.
+        if hasattr(self.model.decoder, "model") and hasattr(self.model.decoder.model, "decoder"):
+            embed_pos = getattr(self.model.decoder.model.decoder, "embed_positions", None)
+            if embed_pos is not None and hasattr(embed_pos, "weights"):
+                num_pos = embed_pos.weights.shape[0] if not embed_pos.weights.is_meta else 2048
+                embed_pos.weights = embed_pos.get_embedding(
+                    num_pos, embed_pos.embedding_dim, embed_pos.padding_idx
+                ).to(self.device)
+
         logger.info("Initialized TrOCR model from %s on device %s.", model, self.model.device)
 
         # Initialize processor

--- a/src/htrflow/pipeline/steps.py
+++ b/src/htrflow/pipeline/steps.py
@@ -32,7 +32,7 @@ class StepMetadata:
 
 class PipelineStepConfig(PydanticBaseModel):
     step: str
-    settings: dict
+    settings: dict | None = None
 
 
 class PipelineConfig(PydanticBaseModel):
@@ -610,4 +610,4 @@ def init_step(step: PipelineStepConfig) -> PipelineStep:
         step_settings: A dictionary containing parameters for the step's
             __init__() method.
     """
-    return STEPS[step.step.lower()].from_config(step.settings)
+    return STEPS[step.step.lower()].from_config(step.settings or {})


### PR DESCRIPTION
## Description

pipeline/steps.py
- Made settings field in PipelineStepConfig optional (dict | None = None), so pipeline YAML configs no longer require an explicit settings: key for steps that use defaults.
- Added a or {} fallback in init_step so a None settings value is safely passed as an empty dict to from_config.
models/huggingface/trocr.py
- Added a workaround for a device mismatch bug in transformers' TrOCRSinusoidalPositionalEmbedding. During inference, position_ids are on CUDA while self.weights remains on CPU (or stored as a meta tensor from the checkpoint). This causes a runtime error.
- Fix: after loading the model, recompute the sinusoidal positional embedding weights from scratch using the layer's own get_embedding() method and move them to the correct device.

Why
These two fixes address runtime errors encountered when running TrOCR-based pipelines:
1. A ValidationError when a pipeline step config omits the settings key.
2. A device mismatch error (Expected all tensors to be on the same device) during TrOCR inference on CUDA.

## Issue ticket number and link from
https://github.com/AI-Riksarkivet/htrflow/issues/47

## Checklist

- [x] I have performed a self-review of my code locally
- [x ] My code follows the style guidelines of this project (e.g. passes ruff lint + mypy type hinting)
- [ ] If it is a core feature, I have added thorough tests.
- [x ] Documentation has been updated or the changes are too minor to be documented
