### PR TITLE
Fix publiccode.yml validation errors

### DIFF
--- a/.github/workflows/publiccodeyml-check.yml
+++ b/.github/workflows/publiccodeyml-check.yml
@@ -1,0 +1,27 @@
+name: Validate publiccode.yml
+
+on:
+  push:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+  pull_request:
+    paths:
+      - "publiccode.yml"
+      - ".github/workflows/publiccodeyml-check.yml"
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: publiccode.yml validation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: italia/publiccode-parser-action@21086c73ec0563e14c6748787efa1b34b025ad8c # v1
+        with:
+          publiccode: "publiccode.yml"
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.4"
+publiccodeYmlVersion: "0"
 name: HTRflow
 url: https://github.com/AI-Riksarkivet/htrflow
 softwareVersion: 0.2.4
@@ -52,6 +52,9 @@ legal:
   license: EUPL-1.2
 maintenance:
   type: internal
+  contacts:
+    - name: AI lab
+      email: ai@riksarkivet.se
 localisation:
   localisationReady: true
   availableLanguages:


### PR DESCRIPTION
The contact email is from pyproject.toml, it's the only one publicly available for the project. Also added a GitHub Actions workflow to validate publiccode.yml automatically on pushes and PRs.