### PR TITLE
Add a private OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '21 5 * * 1'
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Do not publish results to the public OpenSSF API.
+          publish_results: false
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Description

Adds a private OpenSSF Scorecard workflow. Runs `ossf/scorecard-action` on push to `main`, weekly, and on `workflow_dispatch`/`branch_protection_rule` changes. 

If one one want to publish and make badge in readme set " publish_results: true" and set in readme.md  

`[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/AI-Riksarkivet/htrflow/badge)](https://securityscorecards.dev/viewer/?uri=github.com/AI-Riksarkivet/htrflow)`

## Checklist

- [x] I have performed a self-review of my code locally.
- [ ] I have run `ruff format` to format my code.
- [ ] My code passes `ruff check`.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Documentation has been updated or the changes are too minor to be documented.
