### PR TITLE
Extend Python support through 3.14 and test it in CI

### DIFF
--- a/.github/actions/uv/action.yml
+++ b/.github/actions/uv/action.yml
@@ -19,6 +19,6 @@ runs:
       shell: bash
 
     - name: Install project dependencies
-      run: uv sync --all-extras --dev
+      run: uv sync --all-extras --dev --python ${{ inputs.python-version }}
 
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"] 
+        python-version: ["3.10", "3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,14 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 
 dependencies = [
     "jinja2 >= 3.1.5",


### PR DESCRIPTION
## Description

Python support extended to 3.14 (was capped <3.14). CI now tests 3.10/3.12/3.14 instead of just 3.10. Also fixed `uv sync` to pin `--python` explicitly so each matrix job actually tests its own version. 3.10 is soon EOL and should be removed soon
https://www.python.org/downloads/ 

## Checklist

- [x] I have performed a self-review of my code locally.
- [x] I have run `ruff format` to format my code.
- [x] My code passes `ruff check`.
- [ ] If it is a core feature, I have added thorough tests.
- [x] Documentation has been updated or the changes are too minor to be documented.
